### PR TITLE
fix: action repeat wrapper

### DIFF
--- a/sheeprl/envs/wrappers.py
+++ b/sheeprl/envs/wrappers.py
@@ -52,9 +52,10 @@ class ActionRepeat(gym.Wrapper):
 
     def step(self, action):
         done = False
+        truncated = False
         total_reward = 0
         current_step = 0
-        while current_step < self._amount and not done:
+        while current_step < self._amount and not (done or truncated):
             obs, reward, done, truncated, info = self._env.step(action)
             total_reward += reward
             current_step += 1


### PR DESCRIPTION
Fixed the action repeat wrapper, the action is repeated until done or truncated, for a maximum number of times decided by the user in the `action_repeat` hyper-parameter