### PR TITLE
fix: zero division error in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 logs
 poetry.lock
 notebooks
+pytest_*

--- a/howto/register_new_algorithm.md
+++ b/howto/register_new_algorithm.md
@@ -169,7 +169,7 @@ def main():
 
     # Global variables
     global_step = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
     single_global_rollout = int(args.num_envs * args.rollout_steps * world_size)
     num_updates = args.total_steps // single_global_rollout if not args.dry_run else 1
 
@@ -233,7 +233,7 @@ def main():
 
         # Log metrics
         metrics_dict = aggregator.compute()
-        fabric.log("Time/step_per_second", int(global_step / (time.time() - start_time)), global_step)
+        fabric.log("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)), global_step)
         fabric.log_dict(metrics_dict, global_step)
         aggregator.reset()
 

--- a/sheeprl/algos/droq/droq.py
+++ b/sheeprl/algos/droq/droq.py
@@ -223,7 +223,7 @@ def main():
     step_data = TensorDict({}, batch_size=[args.num_envs], device=device)
 
     # Global variables
-    start_time = time.time()
+    start_time = time.perf_counter()
     num_updates = int(args.total_steps // (args.num_envs * fabric.world_size)) if not args.dry_run else 1
     args.learning_starts = args.learning_starts // int(args.num_envs * fabric.world_size) if not args.dry_run else 0
 
@@ -274,7 +274,7 @@ def main():
         # Train the agent
         if global_step > args.learning_starts:
             train(fabric, agent, actor_optimizer, qf_optimizer, alpha_optimizer, rb, aggregator, args)
-        aggregator.update("Time/step_per_second", int(global_step / (time.time() - start_time)))
+        aggregator.update("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)))
         fabric.log_dict(aggregator.compute(), global_step)
         aggregator.reset()
 

--- a/sheeprl/algos/ppo/ppo.py
+++ b/sheeprl/algos/ppo/ppo.py
@@ -204,7 +204,7 @@ def main():
 
     # Global variables
     global_step = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
     single_global_rollout = int(args.num_envs * args.rollout_steps * world_size)
     num_updates = args.total_steps // single_global_rollout if not args.dry_run else 1
 
@@ -316,7 +316,7 @@ def main():
 
         # Log metrics
         metrics_dict = aggregator.compute()
-        fabric.log("Time/step_per_second", int(global_step / (time.time() - start_time)), global_step)
+        fabric.log("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)), global_step)
         fabric.log_dict(metrics_dict, global_step)
         aggregator.reset()
 

--- a/sheeprl/algos/ppo/ppo_decoupled.py
+++ b/sheeprl/algos/ppo/ppo_decoupled.py
@@ -130,7 +130,7 @@ def player(args: PPOArgs, world_collective: TorchCollective, player_trainer_coll
 
     # Global variables
     global_step = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
     single_global_step = int(args.num_envs * args.rollout_steps)
     num_updates = args.total_steps // single_global_step if not args.dry_run else 1
     if single_global_step < world_collective.world_size - 1:
@@ -236,7 +236,7 @@ def player(args: PPOArgs, world_collective: TorchCollective, player_trainer_coll
         )
 
         # Log metrics
-        aggregator.update("Time/step_per_second", int(global_step / (time.time() - start_time)))
+        aggregator.update("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)))
         fabric.log_dict(metrics[0], global_step)
         fabric.log_dict(aggregator.compute(), global_step)
         aggregator.reset()

--- a/sheeprl/algos/ppo_continuous/ppo_continuous.py
+++ b/sheeprl/algos/ppo_continuous/ppo_continuous.py
@@ -190,7 +190,7 @@ def main():
 
     # Global variables
     global_step = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
     single_global_rollout = int(args.num_envs * args.rollout_steps * world_size)
     num_updates = args.total_steps // single_global_rollout if not args.dry_run else 1
 
@@ -299,7 +299,7 @@ def main():
 
         # Log metrics
         metrics_dict = aggregator.compute()
-        fabric.log("Time/step_per_second", int(global_step / (time.time() - start_time)), global_step)
+        fabric.log("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)), global_step)
         fabric.log_dict(metrics_dict, global_step)
         aggregator.reset()
 

--- a/sheeprl/algos/ppo_pixel/ppo_atari.py
+++ b/sheeprl/algos/ppo_pixel/ppo_atari.py
@@ -159,7 +159,7 @@ def player(args: PPOAtariArgs, world_collective: TorchCollective, player_trainer
 
     # Global variables
     global_step = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
     single_global_step = int(args.num_envs * args.rollout_steps)
     num_updates = args.total_steps // single_global_step if not args.dry_run else 1
     if single_global_step < world_collective.world_size - 1:
@@ -261,7 +261,7 @@ def player(args: PPOAtariArgs, world_collective: TorchCollective, player_trainer
         torch.nn.utils.convert_parameters.vector_to_parameters(flattened_parameters, agent.parameters())
 
         # Log metrics
-        aggregator.update("Time/step_per_second", int(global_step / (time.time() - start_time)))
+        aggregator.update("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)))
         fabric.log_dict(metrics[0], global_step)
         fabric.log_dict(aggregator.compute(), global_step)
         aggregator.reset()

--- a/sheeprl/algos/ppo_pixel/ppo_pixel_continuous.py
+++ b/sheeprl/algos/ppo_pixel/ppo_pixel_continuous.py
@@ -152,7 +152,7 @@ def player(args: PPOPixelContinuousArgs, world_collective: TorchCollective, play
 
     # Global variables
     global_step = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
     single_global_step = int(args.num_envs * args.rollout_steps * args.action_repeat)
     num_updates = args.total_steps // single_global_step if not args.dry_run else 1
     if single_global_step < world_collective.world_size - 1:
@@ -259,7 +259,7 @@ def player(args: PPOPixelContinuousArgs, world_collective: TorchCollective, play
         torch.nn.utils.convert_parameters.vector_to_parameters(flattened_parameters, agent.parameters())
 
         # Log metrics
-        aggregator.update("Time/step_per_second", int(global_step / (time.time() - start_time)))
+        aggregator.update("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)))
         fabric.log_dict(metrics[0], global_step)
         fabric.log_dict(aggregator.compute(), global_step)
         aggregator.reset()

--- a/sheeprl/algos/ppo_recurrent/ppo_recurrent.py
+++ b/sheeprl/algos/ppo_recurrent/ppo_recurrent.py
@@ -205,7 +205,7 @@ def main():
 
     # Global variables
     global_step = 0
-    start_time = time.time()
+    start_time = time.perf_counter()
     single_global_rollout = int(args.num_envs * args.rollout_steps * world_size)
     num_updates = args.total_steps // single_global_rollout if not args.dry_run else 1
 
@@ -340,7 +340,7 @@ def main():
 
         # Log metrics
         metrics_dict = aggregator.compute()
-        fabric.log("Time/step_per_second", int(global_step / (time.time() - start_time)), global_step)
+        fabric.log("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)), global_step)
         fabric.log_dict(metrics_dict, global_step)
         aggregator.reset()
 

--- a/sheeprl/algos/sac/sac.py
+++ b/sheeprl/algos/sac/sac.py
@@ -188,7 +188,7 @@ def main():
     step_data = TensorDict({}, batch_size=[args.num_envs], device=device)
 
     # Global variables
-    start_time = time.time()
+    start_time = time.perf_counter()
     num_updates = int(args.total_steps // (args.num_envs * fabric.world_size)) if not args.dry_run else 1
     args.learning_starts = args.learning_starts // int(args.num_envs * fabric.world_size) if not args.dry_run else 0
 
@@ -270,7 +270,7 @@ def main():
                     global_step,
                     args,
                 )
-        aggregator.update("Time/step_per_second", int(global_step / (time.time() - start_time)))
+        aggregator.update("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)))
         fabric.log_dict(aggregator.compute(), global_step)
         aggregator.reset()
 

--- a/sheeprl/algos/sac/sac_decoupled.py
+++ b/sheeprl/algos/sac/sac_decoupled.py
@@ -105,7 +105,7 @@ def player(args: SACArgs, world_collective: TorchCollective, player_trainer_coll
     step_data = TensorDict({}, batch_size=[args.num_envs], device=device)
 
     # Global variables
-    start_time = time.time()
+    start_time = time.perf_counter()
     num_updates = int(args.total_steps // args.num_envs) if not args.dry_run else 1
     args.learning_starts = args.learning_starts // args.num_envs if not args.dry_run else 0
 
@@ -171,7 +171,7 @@ def player(args: SACArgs, world_collective: TorchCollective, player_trainer_coll
             torch.nn.utils.convert_parameters.vector_to_parameters(flattened_parameters, actor.parameters())
 
             fabric.log_dict(metrics[0], global_step)
-        aggregator.update("Time/step_per_second", int(global_step / (time.time() - start_time)))
+        aggregator.update("Time/step_per_second", int(global_step / (time.perf_counter() - start_time)))
         fabric.log_dict(aggregator.compute(), global_step)
         aggregator.reset()
 


### PR DESCRIPTION
time.time() replaced with time.perf_counter() in the calculation of the step_per_second metric to avoid `ZeroDivisionError` when the aggregator updates the step_per_second metric during tests