### PR TITLE
Fix atari dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ mujoco = [
 ]
 atari = [
   "gymnasium[atari]==0.28.*",
+  "gymnasium[accept-rom-license]==0.28.*",
   "gymnasium[other]==0.28.*",
 ]
 


### PR DESCRIPTION
Added `accept-rom-license` to atari dependencies in pyproject.toml