### PR TITLE
Feature/trajectory buffer with priority

### DIFF
--- a/sheeprl/data/buffers.py
+++ b/sheeprl/data/buffers.py
@@ -278,7 +278,7 @@ class TrajectoryReplayBuffer:
         if len(valid_trajectories) == 0:
             raise RuntimeError("No trajectories of length {} found".format(sequence_length))
 
-        if "weights" not in valid_trajectories[0]:
+        if "weights" not in valid_trajectories[0].keys():
             trajectories = random.choices(valid_trajectories, k=batch_size)
             positions = [random.randint(0, len(t) - sequence_length) for t in trajectories]
 

--- a/tests/test_data/test_sequential_buffer.py
+++ b/tests/test_data/test_sequential_buffer.py
@@ -135,7 +135,7 @@ def test_seq_replay_buffer_sample_not_full():
     buf_size = 10
     n_envs = 1
     rb = SequentialReplayBuffer(buf_size, n_envs)
-    rb._buf = TensorDict({"t": torch.ones(10, n_envs, 1) * 20}, batch_size=[10, n_envs])
+    rb._buffer = TensorDict({"t": torch.ones(10, n_envs, 1) * 20}, batch_size=[10, n_envs])
     t = TensorDict({"t": torch.arange(7).reshape(-1, 1, 1) * 1.0}, batch_size=[7, n_envs])
     rb.add(t)
     sample = rb.sample(2, sequence_length=5, n_samples=2)

--- a/tests/test_data/test_trajectory_buffer.py
+++ b/tests/test_data/test_trajectory_buffer.py
@@ -1,0 +1,85 @@
+import pytest
+import torch
+
+from sheeprl.data.buffers import Trajectory, TrajectoryReplayBuffer
+
+
+@pytest.fixture()
+def trajectory():
+    return Trajectory({"obs": torch.rand(5, 3), "rew": torch.rand(5, 1)}, batch_size=5)
+
+
+@pytest.fixture()
+def trajectory2():
+    return Trajectory({"obs": torch.rand(7, 3), "rew": torch.rand(7, 1)}, batch_size=7)
+
+
+def test_add_trajectory(trajectory):
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=5)
+    buffer.add(trajectory)
+    assert len(buffer) == 1
+
+
+def test_add_multiple_trajectories(trajectory, trajectory2):
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=5)
+    buffer.add(trajectory)
+    buffer.add(trajectory2)
+    assert len(buffer) == 2
+
+
+def test_add_none_trajectory(trajectory):
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=5)
+    buffer.add(trajectory)
+    buffer.add(None)
+    assert len(buffer) == 1
+
+
+def test_overflow_trajectories(trajectory, trajectory2):
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=1)
+    buffer.add(trajectory)
+    buffer.add(trajectory2)
+    assert len(buffer) == 1
+    assert buffer[0].shape == torch.Size([7])
+
+
+def test_sample_trajectory(trajectory, trajectory2):
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=1)
+    buffer.add(trajectory)
+    buffer.add(trajectory2)
+    sample = buffer.sample(batch_size=1, sequence_length=4)
+    assert len(sample == 1)
+    assert sample.shape == (4, 1)
+    assert sample.valid_keys == ["obs", "rew"]
+    assert sample["obs"].shape == (4, 1, 3)
+    assert sample["rew"].shape == (4, 1, 1)
+
+
+def test_sample_multiple_trajectories(trajectory, trajectory2):
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=5)
+    buffer.add(trajectory)
+    buffer.add(trajectory2)
+    buffer.add(trajectory)
+    sample = buffer.sample(batch_size=2, sequence_length=4)
+    assert len(sample == 2)
+    assert sample.shape == (4, 2)
+    assert sample.valid_keys == ["obs", "rew"]
+    assert sample["obs"].shape == (4, 2, 3)
+    assert sample["rew"].shape == (4, 2, 1)
+
+
+def test_with_shorter_than_sequence_length_trajectory(trajectory):
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=5)
+    short_traj = Trajectory({"obs": torch.rand(3, 3), "rew": torch.rand(3, 1)}, batch_size=3)
+    buffer.add(short_traj)
+    buffer.add(trajectory)
+    sample = buffer.sample(batch_size=2, sequence_length=4)
+    assert len(sample == 2)
+    assert sample.shape == (4, 2)
+
+
+def test_with_no_long_enough_trajectory():
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=5)
+    short_traj = Trajectory({"obs": torch.rand(3, 3), "rew": torch.rand(3, 1)}, batch_size=3)
+    buffer.add(short_traj)
+    with pytest.raises(RuntimeError):
+        buffer.sample(batch_size=2, sequence_length=4)

--- a/tests/test_data/test_trajectory_buffer.py
+++ b/tests/test_data/test_trajectory_buffer.py
@@ -83,3 +83,14 @@ def test_with_no_long_enough_trajectory():
     buffer.add(short_traj)
     with pytest.raises(RuntimeError):
         buffer.sample(batch_size=2, sequence_length=4)
+
+
+def test_with_memmap():
+    buffer = TrajectoryReplayBuffer(max_num_trajectories=5, memmap=True, memmap_dir="test_memmap")
+    long_traj = Trajectory({"obs": torch.rand(10, 3), "rew": torch.rand(10, 1)}, batch_size=10)
+    buffer.add(long_traj)
+    sample = buffer.sample(batch_size=2, sequence_length=4)
+    assert sample.shape == (4, 2)
+    assert sample.valid_keys == ["obs", "rew"]
+    assert sample["obs"].shape == (4, 2, 3)
+    assert sample["rew"].shape == (4, 2, 1)


### PR DESCRIPTION
## Summary

Add a buffer where each item is a Trajectory and the `sample` method returns chunks of trajectories. If the weights of each sample is provided, sampling takes into account those weights for selecting the trajectories from which extracting the chunk and the starting position of the chunk.  

## Type of Change

- New feature (non-breaking change that adds functionality)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

## Additional Information (Optional)

To be later used with MuZero. We might check if the EpisodeBuffer and the TrajectoryBuffer might be merged in a single buffer.
