### PR TITLE
fix: diambra wrapper converts discrete actions from numpy arrays to int

### DIFF
--- a/sheeprl/envs/diambra.py
+++ b/sheeprl/envs/diambra.py
@@ -21,7 +21,7 @@ class DiambraWrapper(gym.Wrapper):
     def __init__(
         self,
         id: str,
-        action_space: str = "discrete",
+        action_space: str = "diambra.arena.SpaceTypes.DISCRETE",
         screen_size: Union[int, Tuple[int, int]] = 64,
         grayscale: bool = False,
         repeat_action: int = 1,
@@ -41,6 +41,7 @@ class DiambraWrapper(gym.Wrapper):
             warnings.warn("The DIAMBRA n_players setting is disabled")
 
         role = diambra_settings.pop("role", None)
+        self._action_type = "discrete" if "diambra.arena.SpaceTypes.DISCRETE" == action_space else "multi-discrete"
         settings = EnvironmentSettings(
             **diambra_settings,
             **{
@@ -117,6 +118,9 @@ class DiambraWrapper(gym.Wrapper):
         }
 
     def step(self, action: Any) -> Tuple[Any, SupportsFloat, bool, bool, Dict[str, Any]]:
+        if self._action_type == "discrete" and isinstance(action, np.ndarray):
+            action = action.squeeze()
+            action = action.item()
         obs, reward, done, truncated, infos = self.env.step(action)
         infos["env_domain"] = "DIAMBRA"
         return self._convert_obs(obs), reward, done or infos.get("env_done", False), truncated, infos
@@ -130,7 +134,3 @@ class DiambraWrapper(gym.Wrapper):
         obs, infos = self.env.reset(seed=seed, options=options)
         infos["env_domain"] = "DIAMBRA"
         return self._convert_obs(obs), infos
-
-    def close(self) -> None:
-        self.env.close()
-        super().close()


### PR DESCRIPTION
…n discrete control

## Summary

Describe the purpose of the pull request, including:

- The `sheeprl.envs.diambra.DiambraWrapper` converts the actions from numpy arrays to integers whether the actions space is `discrete` and a numpy array is given as action.

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.