### PR TITLE
Fix/minedojo

### DIFF
--- a/howto/learn_in_minedojo.md
+++ b/howto/learn_in_minedojo.md
@@ -1,4 +1,9 @@
 ## Install MineDojo environment
+
+> **Warning**
+>
+> The `Categorical` PyTorch distribution does not work correctly when some probabilities are set to $0$ (the probs set to zero can be sampled anyway). This can cause some errors when filtering actions with the action masks provided by MineDojo. This error is particularly rare, so, we are waiting that the issue is fixed by PyTorch.
+
 First you need to install the JDK 1.8, on Debian based systems you can run the following:
 
 ```bash

--- a/howto/learn_in_minedojo.md
+++ b/howto/learn_in_minedojo.md
@@ -2,7 +2,7 @@
 
 > **Warning**
 >
-> The `Categorical` PyTorch distribution does not work correctly when some probabilities are set to $0$ (the probs set to zero can be sampled anyway). This can cause some errors when filtering actions with the action masks provided by MineDojo. This error is particularly rare, so, we are waiting that the issue is fixed by PyTorch.
+> The `Categorical` PyTorch distribution does not work correctly when some probabilities are set to $0$ (the probs set to zero can be sampled anyway). This can cause some errors when filtering actions with the action masks provided by MineDojo. This error is sporadic, so, we are waiting that the issue is fixed by PyTorch.
 
 First you need to install the JDK 1.8, on Debian based systems you can run the following:
 

--- a/howto/learn_in_minedojo.md
+++ b/howto/learn_in_minedojo.md
@@ -2,7 +2,7 @@
 
 > **Warning**
 >
-> The `Categorical` PyTorch distribution does not work correctly when some probabilities are set to $0$ (the probs set to zero can be sampled anyway). This can cause some errors when filtering actions with the action masks provided by MineDojo. This error is sporadic, so, we are waiting that the issue is fixed by PyTorch.
+> The `Categorical` PyTorch distribution does not work correctly when some probabilities are set to $0$ (the probs set to zero can be sampled anyway). This can cause some errors when filtering actions with the action masks provided by MineDojo. This error is sporadic, so, we are waiting that the issue is fixed by PyTorch. One can track the issue here: https://github.com/pytorch/pytorch/issues/91863
 
 First you need to install the JDK 1.8, on Debian based systems you can run the following:
 

--- a/sheeprl/algos/dreamer_v1/agent.py
+++ b/sheeprl/algos/dreamer_v1/agent.py
@@ -301,15 +301,49 @@ class PlayerDV1(nn.Module):
             expl_actions = [self.actions]
         else:
             expl_actions = []
-            for act in actions:
+            functional_action = actions[0].argmax(dim=-1)
+            for i, act in enumerate(actions):
+                logits = torch.zeros_like(act)
+                # Exploratory action must respect the constraints of the environment
+                if mask is not None:
+                    if i == 0:
+                        logits[torch.logical_not(mask["mask_action_type"].expand_as(logits))] = -torch.inf
+                    elif i == 1:
+                        mask["mask_craft_smelt"] = mask["mask_craft_smelt"].expand_as(logits)
+                        for t in range(functional_action.shape[0]):
+                            for b in range(functional_action.shape[1]):
+                                sampled_action = functional_action[t, b].item()
+                                if sampled_action == 15:  # Craft action
+                                    logits[t, b][torch.logical_not(mask["mask_craft_smelt"][t, b])] = -torch.inf
+                    elif i == 2:
+                        mask["mask_destroy"][t, b] = mask["mask_destroy"].expand_as(logits)
+                        mask["mask_equip_place"] = mask["mask_equip_place"].expand_as(logits)
+                        for t in range(functional_action.shape[0]):
+                            for b in range(functional_action.shape[1]):
+                                sampled_action = functional_action[t, b].item()
+                                if sampled_action in {16, 17}:  # Equip/Place action
+                                    logits[t, b][torch.logical_not(mask["mask_equip_place"][t, b])] = -torch.inf
+                                elif sampled_action == 18:  # Destroy action
+                                    logits[t, b][torch.logical_not(mask["mask_destroy"][t, b])] = -torch.inf
                 sample = (
-                    OneHotCategoricalValidateArgs(logits=torch.zeros_like(act), validate_args=self.validate_args)
+                    OneHotCategoricalValidateArgs(logits=logits, validate_args=self.validate_args)
                     .sample()
                     .to(self.device)
                 )
+                expl_amount = self.expl_amount
+                # If the action[0] was changed, and now it is critical, then we force to change also the other 2 actions
+                # to satisfy the constraints of the environment
+                if (
+                    i in {1, 2}
+                    and actions[0].argmax() != expl_actions[0].argmax()
+                    and expl_actions[0].argmax().item() in {15, 16, 17, 18}
+                ):
+                    expl_amount = 2
                 expl_actions.append(
-                    torch.where(torch.rand(act.shape[:1], device=self.device) < self.expl_amount, sample, act)
+                    torch.where(torch.rand(act.shape[:1], device=self.device) < expl_amount, sample, act)
                 )
+                if mask is not None and i == 0:
+                    functional_action = expl_actions[0].argmax(dim=-1)
             self.actions = torch.cat(expl_actions, -1)
         return tuple(expl_actions)
 
@@ -397,7 +431,7 @@ def build_models(
             keys=cfg.mlp_keys.encoder,
             input_dims=[obs_space[k].shape[0] for k in cfg.mlp_keys.encoder],
             mlp_layers=world_model_cfg.encoder.mlp_layers,
-            dense_units=world_model_cfg.encoderdense_units,
+            dense_units=world_model_cfg.encoder.dense_units,
             activation=eval(world_model_cfg.encoder.dense_act),
             layer_norm=False,
         )

--- a/sheeprl/algos/dreamer_v1/dreamer_v1.py
+++ b/sheeprl/algos/dreamer_v1/dreamer_v1.py
@@ -501,7 +501,6 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,
@@ -560,9 +559,9 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         learning_starts += start_step
     max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
-        player.expl_amount = polynomial_decay(
+        actor.expl_amount = polynomial_decay(
             expl_decay_steps,
-            initial=cfg.algo.player.expl_amount,
+            initial=cfg.algo.actor.expl_amount,
             final=cfg.algo.player.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
@@ -630,7 +629,7 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     mask = {k: v for k, v in preprocessed_obs.items() if k.startswith("mask")}
                     if len(mask) == 0:
                         mask = None
-                    real_actions = actions = player.get_exploration_action(preprocessed_obs, is_continuous, mask)
+                    real_actions = actions = player.get_exploration_action(preprocessed_obs, mask)
                     actions = torch.cat(actions, -1).cpu().numpy()
                     if is_continuous:
                         real_actions = torch.cat(real_actions, -1).cpu().numpy()
@@ -724,14 +723,14 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
             if cfg.algo.player.expl_decay:
                 expl_decay_steps += 1
-                player.expl_amount = polynomial_decay(
+                actor.expl_amount = polynomial_decay(
                     expl_decay_steps,
-                    initial=cfg.algo.player.expl_amount,
+                    initial=cfg.algo.actor.expl_amount,
                     final=cfg.algo.player.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator:
-                aggregator.update("Params/exploration_amout", player.expl_amount)
+                aggregator.update("Params/exploration_amout", actor.expl_amount)
 
         # Log metrics
         if cfg.metric.log_level > 0 and (policy_step - last_log >= cfg.metric.log_every or update == num_updates):

--- a/sheeprl/algos/dreamer_v1/dreamer_v1.py
+++ b/sheeprl/algos/dreamer_v1/dreamer_v1.py
@@ -547,12 +547,12 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
     learning_starts = (cfg.algo.learning_starts // policy_steps_per_update) if not cfg.dry_run else 0
     if cfg.checkpoint.resume_from and not cfg.buffer.checkpoint:
         learning_starts += start_step
-    max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
+    max_step_expl_decay = cfg.algo.actor.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
         actor.expl_amount = polynomial_decay(
             expl_decay_steps,
             initial=cfg.algo.actor.expl_amount,
-            final=cfg.algo.player.expl_min,
+            final=cfg.algo.actor.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
 
@@ -711,12 +711,12 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     )
                 train_step += world_size
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
-            if cfg.algo.player.expl_decay:
+            if cfg.algo.actor.expl_decay:
                 expl_decay_steps += 1
                 actor.expl_amount = polynomial_decay(
                     expl_decay_steps,
                     initial=cfg.algo.actor.expl_amount,
-                    final=cfg.algo.player.expl_min,
+                    final=cfg.algo.actor.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator:

--- a/sheeprl/algos/dreamer_v1/evaluate.py
+++ b/sheeprl/algos/dreamer_v1/evaluate.py
@@ -62,7 +62,6 @@ def evaluate(fabric: Fabric, cfg: Dict[str, Any], state: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,

--- a/sheeprl/algos/dreamer_v2/agent.py
+++ b/sheeprl/algos/dreamer_v2/agent.py
@@ -605,12 +605,12 @@ class MinedojoActor(Actor):
                                 logits[t, b][torch.logical_not(mask["mask_craft_smelt"][t, b])] = -torch.inf
                 elif i == 2:
                     mask["mask_destroy"][t, b] = mask["mask_destroy"].expand_as(logits)
-                    mask["mask_equip/place"] = mask["mask_equip/place"].expand_as(logits)
+                    mask["mask_equip_place"] = mask["mask_equip_place"].expand_as(logits)
                     for t in range(functional_action.shape[0]):
                         for b in range(functional_action.shape[1]):
                             sampled_action = functional_action[t, b].item()
                             if sampled_action in (16, 17):  # Equip/Place action
-                                logits[t, b][torch.logical_not(mask["mask_equip/place"][t, b])] = -torch.inf
+                                logits[t, b][torch.logical_not(mask["mask_equip_place"][t, b])] = -torch.inf
                             elif sampled_action == 18:  # Destroy action
                                 logits[t, b][torch.logical_not(mask["mask_destroy"][t, b])] = -torch.inf
             actions_dist.append(
@@ -752,15 +752,49 @@ class PlayerDV2(nn.Module):
             expl_actions = [self.actions]
         else:
             expl_actions = []
-            for act in actions:
+            functional_action = actions[0].argmax(dim=-1)
+            for i, act in enumerate(actions):
+                logits = torch.zeros_like(act)
+                # Exploratory action must respect the constraints of the environment
+                if mask is not None:
+                    if i == 0:
+                        logits[torch.logical_not(mask["mask_action_type"].expand_as(logits))] = -torch.inf
+                    elif i == 1:
+                        mask["mask_craft_smelt"] = mask["mask_craft_smelt"].expand_as(logits)
+                        for t in range(functional_action.shape[0]):
+                            for b in range(functional_action.shape[1]):
+                                sampled_action = functional_action[t, b].item()
+                                if sampled_action == 15:  # Craft action
+                                    logits[t, b][torch.logical_not(mask["mask_craft_smelt"][t, b])] = -torch.inf
+                    elif i == 2:
+                        mask["mask_destroy"][t, b] = mask["mask_destroy"].expand_as(logits)
+                        mask["mask_equip_place"] = mask["mask_equip_place"].expand_as(logits)
+                        for t in range(functional_action.shape[0]):
+                            for b in range(functional_action.shape[1]):
+                                sampled_action = functional_action[t, b].item()
+                                if sampled_action in {16, 17}:  # Equip/Place action
+                                    logits[t, b][torch.logical_not(mask["mask_equip_place"][t, b])] = -torch.inf
+                                elif sampled_action == 18:  # Destroy action
+                                    logits[t, b][torch.logical_not(mask["mask_destroy"][t, b])] = -torch.inf
                 sample = (
                     OneHotCategoricalValidateArgs(logits=torch.zeros_like(act), validate_args=self.validate_args)
                     .sample()
                     .to(self.device)
                 )
+                expl_amount = self.expl_amount
+                # If the action[0] was changed, and now it is critical, then we force to change also the other 2 actions
+                # to satisfy the constraints of the environment
+                if (
+                    i in {1, 2}
+                    and actions[0].argmax() != expl_actions[0].argmax()
+                    and expl_actions[0].argmax().item() in {15, 16, 17, 18}
+                ):
+                    expl_amount = 2
                 expl_actions.append(
-                    torch.where(torch.rand(act.shape[:1], device=self.device) < self.expl_amount, sample, act)
+                    torch.where(torch.rand(act.shape[:1], device=self.device) < expl_amount, sample, act)
                 )
+                if mask is not None and i == 0:
+                    functional_action = expl_actions[0].argmax(dim=-1)
             self.actions = torch.cat(expl_actions, -1)
         return tuple(expl_actions)
 

--- a/sheeprl/algos/dreamer_v2/agent.py
+++ b/sheeprl/algos/dreamer_v2/agent.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -430,6 +432,8 @@ class Actor(nn.Module):
             Default to 4.
         layer_norm (bool): whether or not to use the layer norm.
             Default to False.
+        expl_amout (float): the exploration amout to use during training.
+            Default to 0.0.
     """
 
     def __init__(
@@ -444,6 +448,7 @@ class Actor(nn.Module):
         activation: nn.Module = nn.ELU,
         mlp_layers: int = 4,
         layer_norm: bool = False,
+        expl_amount: float = 0.0,
     ) -> None:
         super().__init__()
         self.distribution = distribution_cfg.pop("type", "auto").lower()
@@ -477,6 +482,15 @@ class Actor(nn.Module):
         self.init_std = torch.tensor(init_std)
         self.min_std = min_std
         self.distribution_cfg = distribution_cfg
+        self._expl_amount = expl_amount
+
+    @property
+    def expl_amount(self) -> float:
+        return self._expl_amount
+
+    @expl_amount.setter
+    def expl_amount(self, amount: float):
+        self._expl_amount = amount
 
     def forward(
         self, state: Tensor, is_training: bool = True, mask: Optional[Dict[str, Tensor]] = None
@@ -541,6 +555,27 @@ class Actor(nn.Module):
                     actions.append(actions_dist[-1].mode)
         return tuple(actions), tuple(actions_dist)
 
+    def add_exploration_noise(
+        self, actions: Sequence[Tensor], mask: Optional[Dict[str, Tensor]] = None
+    ) -> Sequence[Tensor]:
+        if self.is_continuous:
+            actions = torch.cat(actions, -1)
+            if self._expl_amount > 0.0:
+                actions = torch.clip(Normal(actions, self._expl_amount).sample(), -1, 1)
+            expl_actions = [actions]
+        else:
+            expl_actions = []
+            for act in actions:
+                sample = (
+                    OneHotCategoricalValidateArgs(logits=torch.zeros_like(act), validate_args=False)
+                    .sample()
+                    .to(act.device)
+                )
+                expl_actions.append(
+                    torch.where(torch.rand(act.shape[:1], device=act.device) < self._expl_amount, sample, act)
+                )
+        return tuple(expl_actions)
+
 
 class MinedojoActor(Actor):
     def __init__(
@@ -555,18 +590,20 @@ class MinedojoActor(Actor):
         activation: nn.Module = nn.ELU,
         mlp_layers: int = 4,
         layer_norm: bool = False,
+        expl_amount: float = 0.0,
     ) -> None:
         super().__init__(
             latent_state_size=latent_state_size,
             actions_dim=actions_dim,
             is_continuous=is_continuous,
+            distribution_cfg=distribution_cfg,
             init_std=init_std,
             min_std=min_std,
             dense_units=dense_units,
             activation=activation,
             mlp_layers=mlp_layers,
             layer_norm=layer_norm,
-            distribution_cfg=distribution_cfg,
+            expl_amount=expl_amount,
         )
 
     def forward(
@@ -626,6 +663,51 @@ class MinedojoActor(Actor):
                 functional_action = actions[0].argmax(dim=-1)  # [T, B]
         return tuple(actions), tuple(actions_dist)
 
+    def add_exploration_noise(
+        self, actions: Sequence[Tensor], mask: Optional[Dict[str, Tensor]] = None
+    ) -> Sequence[Tensor]:
+        expl_actions = []
+        functional_action = actions[0].argmax(dim=-1)
+        for i, act in enumerate(actions):
+            logits = torch.zeros_like(act)
+            # Exploratory action must respect the constraints of the environment
+            if mask is not None:
+                if i == 0:
+                    logits[torch.logical_not(mask["mask_action_type"].expand_as(logits))] = -torch.inf
+                elif i == 1:
+                    mask["mask_craft_smelt"] = mask["mask_craft_smelt"].expand_as(logits)
+                    for t in range(functional_action.shape[0]):
+                        for b in range(functional_action.shape[1]):
+                            sampled_action = functional_action[t, b].item()
+                            if sampled_action == 15:  # Craft action
+                                logits[t, b][torch.logical_not(mask["mask_craft_smelt"][t, b])] = -torch.inf
+                elif i == 2:
+                    mask["mask_destroy"][t, b] = mask["mask_destroy"].expand_as(logits)
+                    mask["mask_equip_place"] = mask["mask_equip_place"].expand_as(logits)
+                    for t in range(functional_action.shape[0]):
+                        for b in range(functional_action.shape[1]):
+                            sampled_action = functional_action[t, b].item()
+                            if sampled_action in {16, 17}:  # Equip/Place action
+                                logits[t, b][torch.logical_not(mask["mask_equip_place"][t, b])] = -torch.inf
+                            elif sampled_action == 18:  # Destroy action
+                                logits[t, b][torch.logical_not(mask["mask_destroy"][t, b])] = -torch.inf
+            sample = (
+                OneHotCategoricalValidateArgs(logits=torch.zeros_like(act), validate_args=False).sample().to(act.device)
+            )
+            expl_amount = self.expl_amount
+            # If the action[0] was changed, and now it is critical, then we force to change also the other 2 actions
+            # to satisfy the constraints of the environment
+            if (
+                i in {1, 2}
+                and actions[0].argmax() != expl_actions[0].argmax()
+                and expl_actions[0].argmax().item() in {15, 16, 17, 18}
+            ):
+                expl_amount = 2
+            expl_actions.append(torch.where(torch.rand(act.shape[:1], device=self.device) < expl_amount, sample, act))
+            if mask is not None and i == 0:
+                functional_action = expl_actions[0].argmax(dim=-1)
+        return tuple(expl_actions)
+
 
 class WorldModel(nn.Module):
     """
@@ -665,7 +747,6 @@ class PlayerDV2(nn.Module):
         representation_model (nn.Module): the representation model.
         actor (nn.Module): the actor.
         actions_dim (Sequence[int]): the dimension of the actions.
-        expl_amount (float): the exploration amout to use during training.
         num_envs (int): the number of environments.
         stochastic_size (int): the size of the stochastic state.
         recurrent_state_size (int): the size of the recurrent state.
@@ -682,7 +763,6 @@ class PlayerDV2(nn.Module):
         representation_model: nn.Module,
         actor: nn.Module,
         actions_dim: Sequence[int],
-        expl_amount: float,
         num_envs: int,
         stochastic_size: int,
         recurrent_state_size: int,
@@ -695,7 +775,6 @@ class PlayerDV2(nn.Module):
         self.representation_model = representation_model
         self.actor = actor
         self.device = device
-        self.expl_amount = expl_amount
         self.actions_dim = actions_dim
         self.stochastic_size = stochastic_size
         self.discrete_size = discrete_size
@@ -722,12 +801,7 @@ class PlayerDV2(nn.Module):
             self.recurrent_state[:, reset_envs] = torch.zeros_like(self.recurrent_state[:, reset_envs])
             self.stochastic_state[:, reset_envs] = torch.zeros_like(self.stochastic_state[:, reset_envs])
 
-    def get_exploration_action(
-        self,
-        obs: Dict[str, Tensor],
-        is_continuous: bool,
-        mask: Optional[Dict[str, Tensor]] = None,
-    ) -> Tensor:
+    def get_exploration_action(self, obs: Dict[str, Tensor], mask: Optional[Dict[str, Tensor]] = None) -> Tensor:
         """
         Return the actions with a certain amount of noise for exploration.
 
@@ -741,62 +815,11 @@ class PlayerDV2(nn.Module):
             The actions the agent has to perform.
         """
         actions = self.get_greedy_action(obs, mask=mask)
-        if is_continuous:
-            self.actions = torch.cat(actions, -1)
-            if self.expl_amount > 0.0:
-                self.actions = torch.clip(
-                    Normal(self.actions, self.expl_amount, validate_args=self.validate_args).sample(),
-                    -1,
-                    1,
-                )
-            expl_actions = [self.actions]
-        else:
-            expl_actions = []
-            functional_action = actions[0].argmax(dim=-1)
-            for i, act in enumerate(actions):
-                logits = torch.zeros_like(act)
-                # Exploratory action must respect the constraints of the environment
-                if mask is not None:
-                    if i == 0:
-                        logits[torch.logical_not(mask["mask_action_type"].expand_as(logits))] = -torch.inf
-                    elif i == 1:
-                        mask["mask_craft_smelt"] = mask["mask_craft_smelt"].expand_as(logits)
-                        for t in range(functional_action.shape[0]):
-                            for b in range(functional_action.shape[1]):
-                                sampled_action = functional_action[t, b].item()
-                                if sampled_action == 15:  # Craft action
-                                    logits[t, b][torch.logical_not(mask["mask_craft_smelt"][t, b])] = -torch.inf
-                    elif i == 2:
-                        mask["mask_destroy"][t, b] = mask["mask_destroy"].expand_as(logits)
-                        mask["mask_equip_place"] = mask["mask_equip_place"].expand_as(logits)
-                        for t in range(functional_action.shape[0]):
-                            for b in range(functional_action.shape[1]):
-                                sampled_action = functional_action[t, b].item()
-                                if sampled_action in {16, 17}:  # Equip/Place action
-                                    logits[t, b][torch.logical_not(mask["mask_equip_place"][t, b])] = -torch.inf
-                                elif sampled_action == 18:  # Destroy action
-                                    logits[t, b][torch.logical_not(mask["mask_destroy"][t, b])] = -torch.inf
-                sample = (
-                    OneHotCategoricalValidateArgs(logits=torch.zeros_like(act), validate_args=self.validate_args)
-                    .sample()
-                    .to(self.device)
-                )
-                expl_amount = self.expl_amount
-                # If the action[0] was changed, and now it is critical, then we force to change also the other 2 actions
-                # to satisfy the constraints of the environment
-                if (
-                    i in {1, 2}
-                    and actions[0].argmax() != expl_actions[0].argmax()
-                    and expl_actions[0].argmax().item() in {15, 16, 17, 18}
-                ):
-                    expl_amount = 2
-                expl_actions.append(
-                    torch.where(torch.rand(act.shape[:1], device=self.device) < expl_amount, sample, act)
-                )
-                if mask is not None and i == 0:
-                    functional_action = expl_actions[0].argmax(dim=-1)
-            self.actions = torch.cat(expl_actions, -1)
-        return tuple(expl_actions)
+        expl_actions = None
+        if self.actor.expl_amount > 0:
+            expl_actions = self.actor.add_exploration_noise(actions, mask=mask)
+            self.actions = torch.cat(expl_actions, dim=-1)
+        return expl_actions or actions
 
     def get_greedy_action(
         self,

--- a/sheeprl/algos/dreamer_v2/dreamer_v2.py
+++ b/sheeprl/algos/dreamer_v2/dreamer_v2.py
@@ -585,12 +585,12 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
     learning_starts = cfg.algo.learning_starts // policy_steps_per_update if not cfg.dry_run else 0
     if cfg.checkpoint.resume_from and not cfg.buffer.checkpoint:
         learning_starts += start_step
-    max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
+    max_step_expl_decay = cfg.algo.actor.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
         actor.expl_amount = polynomial_decay(
             expl_decay_steps,
             initial=cfg.algo.actor.expl_amount,
-            final=cfg.algo.player.expl_min,
+            final=cfg.algo.actor.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
 
@@ -789,12 +789,12 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     per_rank_gradient_steps += 1
                 train_step += world_size
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
-            if cfg.algo.player.expl_decay:
+            if cfg.algo.actor.expl_decay:
                 expl_decay_steps += 1
                 actor.expl_amount = polynomial_decay(
                     expl_decay_steps,
                     initial=cfg.algo.actor.expl_amount,
-                    final=cfg.algo.player.expl_min,
+                    final=cfg.algo.actor.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:

--- a/sheeprl/algos/dreamer_v2/dreamer_v2.py
+++ b/sheeprl/algos/dreamer_v2/dreamer_v2.py
@@ -525,7 +525,6 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,
@@ -597,9 +596,9 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         learning_starts += start_step
     max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
-        player.expl_amount = polynomial_decay(
+        actor.expl_amount = polynomial_decay(
             expl_decay_steps,
-            initial=cfg.algo.player.expl_amount,
+            initial=cfg.algo.actor.expl_amount,
             final=cfg.algo.player.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
@@ -675,7 +674,7 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     mask = {k: v for k, v in preprocessed_obs.items() if k.startswith("mask")}
                     if len(mask) == 0:
                         mask = None
-                    real_actions = actions = player.get_exploration_action(preprocessed_obs, is_continuous, mask)
+                    real_actions = actions = player.get_exploration_action(preprocessed_obs, mask)
                     actions = torch.cat(actions, -1).cpu().numpy()
                     if is_continuous:
                         real_actions = torch.cat(real_actions, -1).cpu().numpy()
@@ -801,14 +800,14 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
             if cfg.algo.player.expl_decay:
                 expl_decay_steps += 1
-                player.expl_amount = polynomial_decay(
+                actor.expl_amount = polynomial_decay(
                     expl_decay_steps,
-                    initial=cfg.algo.player.expl_amount,
+                    initial=cfg.algo.actor.expl_amount,
                     final=cfg.algo.player.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:
-                aggregator.update("Params/exploration_amout", player.expl_amount)
+                aggregator.update("Params/exploration_amout", actor.expl_amount)
 
         # Log metrics
         if cfg.metric.log_level > 0 and (policy_step - last_log >= cfg.metric.log_every or update == num_updates):

--- a/sheeprl/algos/dreamer_v2/evaluate.py
+++ b/sheeprl/algos/dreamer_v2/evaluate.py
@@ -62,7 +62,6 @@ def evaluate(fabric: Fabric, cfg: Dict[str, Any], state: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,

--- a/sheeprl/algos/dreamer_v3/agent.py
+++ b/sheeprl/algos/dreamer_v3/agent.py
@@ -557,15 +557,49 @@ class PlayerDV3(nn.Module):
             expl_actions = [self.actions]
         else:
             expl_actions = []
-            for act in actions:
+            functional_action = actions[0].argmax(dim=-1)
+            for i, act in enumerate(actions):
+                logits = torch.zeros_like(act)
+                # Exploratory action must respect the constraints of the environment
+                if mask is not None:
+                    if i == 0:
+                        logits[torch.logical_not(mask["mask_action_type"].expand_as(logits))] = -torch.inf
+                    elif i == 1:
+                        mask["mask_craft_smelt"] = mask["mask_craft_smelt"].expand_as(logits)
+                        for t in range(functional_action.shape[0]):
+                            for b in range(functional_action.shape[1]):
+                                sampled_action = functional_action[t, b].item()
+                                if sampled_action == 15:  # Craft action
+                                    logits[t, b][torch.logical_not(mask["mask_craft_smelt"][t, b])] = -torch.inf
+                    elif i == 2:
+                        mask["mask_destroy"][t, b] = mask["mask_destroy"].expand_as(logits)
+                        mask["mask_equip_place"] = mask["mask_equip_place"].expand_as(logits)
+                        for t in range(functional_action.shape[0]):
+                            for b in range(functional_action.shape[1]):
+                                sampled_action = functional_action[t, b].item()
+                                if sampled_action in {16, 17}:  # Equip/Place action
+                                    logits[t, b][torch.logical_not(mask["mask_equip_place"][t, b])] = -torch.inf
+                                elif sampled_action == 18:  # Destroy action
+                                    logits[t, b][torch.logical_not(mask["mask_destroy"][t, b])] = -torch.inf
                 sample = (
                     OneHotCategoricalValidateArgs(logits=torch.zeros_like(act), validate_args=False)
                     .sample()
                     .to(self.device)
                 )
+                expl_amount = self.expl_amount
+                # If the action[0] was changed, and now it is critical, then we force to change also the other 2 actions
+                # to satisfy the constraints of the environment
+                if (
+                    i in {1, 2}
+                    and actions[0].argmax() != expl_actions[0].argmax()
+                    and expl_actions[0].argmax().item() in {15, 16, 17, 18}
+                ):
+                    expl_amount = 2
                 expl_actions.append(
-                    torch.where(torch.rand(act.shape[:1], device=self.device) < self.expl_amount, sample, act)
+                    torch.where(torch.rand(act.shape[:1], device=self.device) < expl_amount, sample, act)
                 )
+                if mask is not None and i == 0:
+                    functional_action = expl_actions[0].argmax(dim=-1)
             self.actions = torch.cat(expl_actions, -1)
         return tuple(expl_actions)
 
@@ -757,9 +791,10 @@ class MinedojoActor(Actor):
         init_std: float = 0,
         min_std: float = 0.1,
         dense_units: int = 1024,
-        dense_act: nn.Module = nn.SiLU,
+        activation: nn.Module = nn.SiLU,
         mlp_layers: int = 5,
         layer_norm: bool = True,
+        unimix: float = 0.01,
     ) -> None:
         super().__init__(
             latent_state_size=latent_state_size,
@@ -769,9 +804,10 @@ class MinedojoActor(Actor):
             init_std=init_std,
             min_std=min_std,
             dense_units=dense_units,
-            dense_act=dense_act,
+            activation=activation,
             mlp_layers=mlp_layers,
             layer_norm=layer_norm,
+            unimix=unimix,
         )
 
     def forward(
@@ -789,7 +825,7 @@ class MinedojoActor(Actor):
             The distribution of the actions
         """
         out: Tensor = self.model(state)
-        actions_logits: List[Tensor] = [head(out) for head in self.mlp_heads]
+        actions_logits: List[Tensor] = [self._uniform_mix(head(out)) for head in self.mlp_heads]
         actions_dist: List[Distribution] = []
         actions: List[Tensor] = []
         functional_action = None
@@ -806,12 +842,12 @@ class MinedojoActor(Actor):
                                 logits[t, b][torch.logical_not(mask["mask_craft_smelt"][t, b])] = -torch.inf
                 elif i == 2:
                     mask["mask_destroy"][t, b] = mask["mask_destroy"].expand_as(logits)
-                    mask["mask_equip/place"] = mask["mask_equip/place"].expand_as(logits)
+                    mask["mask_equip_place"] = mask["mask_equip_place"].expand_as(logits)
                     for t in range(functional_action.shape[0]):
                         for b in range(functional_action.shape[1]):
                             sampled_action = functional_action[t, b].item()
                             if sampled_action in (16, 17):  # Equip/Place action
-                                logits[t, b][torch.logical_not(mask["mask_equip/place"][t, b])] = -torch.inf
+                                logits[t, b][torch.logical_not(mask["mask_equip_place"][t, b])] = -torch.inf
                             elif sampled_action == 18:  # Destroy action
                                 logits[t, b][torch.logical_not(mask["mask_destroy"][t, b])] = -torch.inf
             actions_dist.append(

--- a/sheeprl/algos/dreamer_v3/dreamer_v3.py
+++ b/sheeprl/algos/dreamer_v3/dreamer_v3.py
@@ -458,7 +458,6 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         world_model.rssm,
         actor.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,
@@ -527,9 +526,9 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         learning_starts += start_step
     max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * fabric.world_size)
     if cfg.checkpoint.resume_from:
-        player.expl_amount = polynomial_decay(
+        actor.expl_amount = polynomial_decay(
             expl_decay_steps,
-            initial=cfg.algo.player.expl_amount,
+            initial=cfg.algo.actor.expl_amount,
             final=cfg.algo.player.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
@@ -598,7 +597,7 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     mask = {k: v for k, v in preprocessed_obs.items() if k.startswith("mask")}
                     if len(mask) == 0:
                         mask = None
-                    real_actions = actions = player.get_exploration_action(preprocessed_obs, is_continuous, mask)
+                    real_actions = actions = player.get_exploration_action(preprocessed_obs, mask)
                     actions = torch.cat(actions, -1).cpu().numpy()
                     if is_continuous:
                         real_actions = torch.cat(real_actions, dim=-1).cpu().numpy()
@@ -718,14 +717,14 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
             if cfg.algo.player.expl_decay:
                 expl_decay_steps += 1
-                player.expl_amount = polynomial_decay(
+                actor.expl_amount = polynomial_decay(
                     expl_decay_steps,
-                    initial=cfg.algo.player.expl_amount,
+                    initial=cfg.algo.actor.expl_amount,
                     final=cfg.algo.player.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:
-                aggregator.update("Params/exploration_amout", player.expl_amount)
+                aggregator.update("Params/exploration_amout", actor.expl_amount)
 
         # Log metrics
         if cfg.metric.log_level > 0 and (policy_step - last_log >= cfg.metric.log_every or update == num_updates):

--- a/sheeprl/algos/dreamer_v3/dreamer_v3.py
+++ b/sheeprl/algos/dreamer_v3/dreamer_v3.py
@@ -515,12 +515,12 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
     learning_starts = cfg.algo.learning_starts // policy_steps_per_update if not cfg.dry_run else 0
     if cfg.checkpoint.resume_from and not cfg.buffer.checkpoint:
         learning_starts += start_step
-    max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * fabric.world_size)
+    max_step_expl_decay = cfg.algo.actor.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * fabric.world_size)
     if cfg.checkpoint.resume_from:
         actor.expl_amount = polynomial_decay(
             expl_decay_steps,
             initial=cfg.algo.actor.expl_amount,
-            final=cfg.algo.player.expl_min,
+            final=cfg.algo.actor.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
 
@@ -706,12 +706,12 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     per_rank_gradient_steps += 1
                 train_step += world_size
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
-            if cfg.algo.player.expl_decay:
+            if cfg.algo.actor.expl_decay:
                 expl_decay_steps += 1
                 actor.expl_amount = polynomial_decay(
                     expl_decay_steps,
                     initial=cfg.algo.actor.expl_amount,
-                    final=cfg.algo.player.expl_min,
+                    final=cfg.algo.actor.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:

--- a/sheeprl/algos/dreamer_v3/evaluate.py
+++ b/sheeprl/algos/dreamer_v3/evaluate.py
@@ -61,7 +61,6 @@ def evaluate(fabric: Fabric, cfg: Dict[str, Any], state: Dict[str, Any]):
         world_model.rssm,
         actor.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,

--- a/sheeprl/algos/p2e_dv1/evaluate.py
+++ b/sheeprl/algos/p2e_dv1/evaluate.py
@@ -63,7 +63,6 @@ def evaluate(fabric: Fabric, cfg: Dict[str, Any], state: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor_task.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,

--- a/sheeprl/algos/p2e_dv1/p2e_dv1.py
+++ b/sheeprl/algos/p2e_dv1/p2e_dv1.py
@@ -538,7 +538,6 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor_exploration.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,
@@ -622,9 +621,15 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         learning_starts += start_step
     max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
-        player.expl_amount = polynomial_decay(
+        actor_task.expl_amount = polynomial_decay(
             expl_decay_steps,
-            initial=cfg.algo.player.expl_amount,
+            initial=cfg.algo.actor.expl_amount,
+            final=cfg.algo.player.expl_min,
+            max_decay_steps=max_step_expl_decay,
+        )
+        actor_exploration.expl_amount = polynomial_decay(
+            expl_decay_steps,
+            initial=cfg.algo.actor.expl_amount,
             final=cfg.algo.player.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
@@ -700,7 +705,7 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     mask = {k: v for k, v in preprocessed_obs.items() if k.startswith("mask")}
                     if len(mask) == 0:
                         mask = None
-                    real_actions = actions = player.get_exploration_action(preprocessed_obs, is_continuous, mask)
+                    real_actions = actions = player.get_exploration_action(preprocessed_obs, mask)
                     actions = torch.cat(actions, -1).cpu().numpy()
                     if is_continuous:
                         real_actions = torch.cat(real_actions, -1).cpu().numpy()
@@ -803,14 +808,21 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
             if cfg.algo.player.expl_decay:
                 expl_decay_steps += 1
-                player.expl_amount = polynomial_decay(
+                actor_task.expl_amount = polynomial_decay(
                     expl_decay_steps,
-                    initial=cfg.algo.player.expl_amount,
+                    initial=cfg.algo.actor.expl_amount,
+                    final=cfg.algo.player.expl_min,
+                    max_decay_steps=max_step_expl_decay,
+                )
+                actor_exploration.expl_amount = polynomial_decay(
+                    expl_decay_steps,
+                    initial=cfg.algo.actor.expl_amount,
                     final=cfg.algo.player.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:
-                aggregator.update("Params/exploration_amout", player.expl_amount)
+                aggregator.update("Params/exploration_amout_task", actor_task.expl_amount)
+                aggregator.update("Params/exploration_amout_exploration", actor_exploration.expl_amount)
 
         # Log metrics
         if cfg.metric.log_level > 0 and (policy_step - last_log >= cfg.metric.log_every or update == num_updates):

--- a/sheeprl/algos/p2e_dv1/p2e_dv1.py
+++ b/sheeprl/algos/p2e_dv1/p2e_dv1.py
@@ -610,18 +610,18 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
     exploration_updates = min(num_updates, exploration_updates)
     if cfg.checkpoint.resume_from and not cfg.buffer.checkpoint:
         learning_starts += start_step
-    max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
+    max_step_expl_decay = cfg.algo.actor.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
         actor_task.expl_amount = polynomial_decay(
             expl_decay_steps,
             initial=cfg.algo.actor.expl_amount,
-            final=cfg.algo.player.expl_min,
+            final=cfg.algo.actor.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
         actor_exploration.expl_amount = polynomial_decay(
             expl_decay_steps,
             initial=cfg.algo.actor.expl_amount,
-            final=cfg.algo.player.expl_min,
+            final=cfg.algo.actor.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
 
@@ -797,18 +797,18 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     )
                 train_step += world_size
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
-            if cfg.algo.player.expl_decay:
+            if cfg.algo.actor.expl_decay:
                 expl_decay_steps += 1
                 actor_task.expl_amount = polynomial_decay(
                     expl_decay_steps,
                     initial=cfg.algo.actor.expl_amount,
-                    final=cfg.algo.player.expl_min,
+                    final=cfg.algo.actor.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
                 actor_exploration.expl_amount = polynomial_decay(
                     expl_decay_steps,
                     initial=cfg.algo.actor.expl_amount,
-                    final=cfg.algo.player.expl_min,
+                    final=cfg.algo.actor.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:

--- a/sheeprl/algos/p2e_dv2/evaluate.py
+++ b/sheeprl/algos/p2e_dv2/evaluate.py
@@ -63,7 +63,6 @@ def evaluate(fabric: Fabric, cfg: Dict[str, Any], state: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor_task.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,

--- a/sheeprl/algos/p2e_dv2/p2e_dv2.py
+++ b/sheeprl/algos/p2e_dv2/p2e_dv2.py
@@ -677,7 +677,6 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         world_model.rssm.representation_model.module,
         actor_exploration.module,
         actions_dim,
-        cfg.algo.player.expl_amount,
         cfg.env.num_envs,
         cfg.algo.world_model.stochastic_size,
         cfg.algo.world_model.recurrent_model.recurrent_state_size,
@@ -771,9 +770,15 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
         learning_starts += start_step
     max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
-        player.expl_amount = polynomial_decay(
+        actor_task.expl_amount = polynomial_decay(
             expl_decay_steps,
-            initial=cfg.algo.player.expl_amount,
+            initial=cfg.algo.actor.expl_amount,
+            final=cfg.algo.player.expl_min,
+            max_decay_steps=max_step_expl_decay,
+        )
+        actor_exploration.expl_amount = polynomial_decay(
+            expl_decay_steps,
+            initial=cfg.algo.actor.expl_amount,
             final=cfg.algo.player.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
@@ -861,7 +866,7 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     mask = {k: v for k, v in preprocessed_obs.items() if k.startswith("mask")}
                     if len(mask) == 0:
                         mask = None
-                    real_actions = actions = player.get_exploration_action(preprocessed_obs, is_continuous, mask)
+                    real_actions = actions = player.get_exploration_action(preprocessed_obs, mask)
                     actions = torch.cat(actions, -1).cpu().numpy()
                     if is_continuous:
                         real_actions = torch.cat(real_actions, -1).cpu().numpy()
@@ -999,14 +1004,21 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
             if cfg.algo.player.expl_decay:
                 expl_decay_steps += 1
-                player.expl_amount = polynomial_decay(
+                actor_task.expl_amount = polynomial_decay(
                     expl_decay_steps,
-                    initial=cfg.algo.player.expl_amount,
+                    initial=cfg.algo.actor.expl_amount,
+                    final=cfg.algo.player.expl_min,
+                    max_decay_steps=max_step_expl_decay,
+                )
+                actor_exploration.expl_amount = polynomial_decay(
+                    expl_decay_steps,
+                    initial=cfg.algo.actor.expl_amount,
                     final=cfg.algo.player.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:
-                aggregator.update("Params/exploration_amout", player.expl_amount)
+                aggregator.update("Params/exploration_amout_task", actor_task.expl_amount)
+                aggregator.update("Params/exploration_amout_exploration", actor_exploration.expl_amount)
 
         # Log metrics
         if cfg.metric.log_level > 0 and (policy_step - last_log >= cfg.metric.log_every or update == num_updates):

--- a/sheeprl/algos/p2e_dv2/p2e_dv2.py
+++ b/sheeprl/algos/p2e_dv2/p2e_dv2.py
@@ -759,18 +759,18 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
     learning_starts = cfg.algo.learning_starts // policy_steps_per_update if not cfg.dry_run else 0
     if cfg.checkpoint.resume_from and not cfg.buffer.checkpoint:
         learning_starts += start_step
-    max_step_expl_decay = cfg.algo.player.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
+    max_step_expl_decay = cfg.algo.actor.max_step_expl_decay // (cfg.algo.per_rank_gradient_steps * world_size)
     if cfg.checkpoint.resume_from:
         actor_task.expl_amount = polynomial_decay(
             expl_decay_steps,
             initial=cfg.algo.actor.expl_amount,
-            final=cfg.algo.player.expl_min,
+            final=cfg.algo.actor.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
         actor_exploration.expl_amount = polynomial_decay(
             expl_decay_steps,
             initial=cfg.algo.actor.expl_amount,
-            final=cfg.algo.player.expl_min,
+            final=cfg.algo.actor.expl_min,
             max_decay_steps=max_step_expl_decay,
         )
 
@@ -993,18 +993,18 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
                     )
                 train_step += world_size
             updates_before_training = cfg.algo.train_every // policy_steps_per_update
-            if cfg.algo.player.expl_decay:
+            if cfg.algo.actor.expl_decay:
                 expl_decay_steps += 1
                 actor_task.expl_amount = polynomial_decay(
                     expl_decay_steps,
                     initial=cfg.algo.actor.expl_amount,
-                    final=cfg.algo.player.expl_min,
+                    final=cfg.algo.actor.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
                 actor_exploration.expl_amount = polynomial_decay(
                     expl_decay_steps,
                     initial=cfg.algo.actor.expl_amount,
-                    final=cfg.algo.player.expl_min,
+                    final=cfg.algo.actor.expl_min,
                     max_decay_steps=max_step_expl_decay,
                 )
             if aggregator and not aggregator.disabled:

--- a/sheeprl/configs/algo/dreamer_v1.yaml
+++ b/sheeprl/configs/algo/dreamer_v1.yaml
@@ -91,6 +91,7 @@ actor:
   mlp_layers: ${algo.mlp_layers}
   dense_units: ${algo.dense_units}
   clip_gradients: 100.0
+  expl_amount: 0.3
 
   # Actor optimizer
   optimizer:
@@ -114,6 +115,5 @@ critic:
 # Player agent (it interacts with the environment)
 player:
   expl_min: 0.0
-  expl_amount: 0.3
   expl_decay: False
   max_step_expl_decay: 200000

--- a/sheeprl/configs/algo/dreamer_v1.yaml
+++ b/sheeprl/configs/algo/dreamer_v1.yaml
@@ -92,6 +92,9 @@ actor:
   dense_units: ${algo.dense_units}
   clip_gradients: 100.0
   expl_amount: 0.3
+  expl_min: 0.0
+  expl_decay: False
+  max_step_expl_decay: 200000
 
   # Actor optimizer
   optimizer:
@@ -111,9 +114,3 @@ critic:
     lr: 8e-5
     eps: 1e-5
     weight_decay: 0
-
-# Player agent (it interacts with the environment)
-player:
-  expl_min: 0.0
-  expl_decay: False
-  max_step_expl_decay: 200000

--- a/sheeprl/configs/algo/dreamer_v2.yaml
+++ b/sheeprl/configs/algo/dreamer_v2.yaml
@@ -105,6 +105,9 @@ actor:
   dense_units: ${algo.dense_units}
   clip_gradients: 100.0
   expl_amount: 0.0
+  expl_min: 0.0
+  expl_decay: False
+  max_step_expl_decay: 0
 
   # Actor optimizer
   optimizer:
@@ -129,7 +132,4 @@ critic:
 
 # Player agent (it interacts with the environment)
 player:
-  expl_min: 0.0
-  expl_decay: False
-  max_step_expl_decay: 0
   discrete_size: ${algo.world_model.discrete_size}

--- a/sheeprl/configs/algo/dreamer_v2.yaml
+++ b/sheeprl/configs/algo/dreamer_v2.yaml
@@ -104,6 +104,7 @@ actor:
   layer_norm: ${algo.layer_norm}
   dense_units: ${algo.dense_units}
   clip_gradients: 100.0
+  expl_amount: 0.0
 
   # Actor optimizer
   optimizer:
@@ -129,7 +130,6 @@ critic:
 # Player agent (it interacts with the environment)
 player:
   expl_min: 0.0
-  expl_amount: 0.0
   expl_decay: False
   max_step_expl_decay: 0
   discrete_size: ${algo.world_model.discrete_size}

--- a/sheeprl/configs/algo/dreamer_v3.yaml
+++ b/sheeprl/configs/algo/dreamer_v3.yaml
@@ -107,6 +107,9 @@ actor:
   dense_units: ${algo.dense_units}
   clip_gradients: 100.0
   expl_amount: 0.0
+  expl_min: 0.0
+  expl_decay: False
+  max_step_expl_decay: 0
   
   # Disttributed percentile model (used to scale the values)
   moments:
@@ -141,7 +144,4 @@ critic:
 
 # Player agent (it interacts with the environment)
 player:
-  expl_min: 0.0
-  expl_decay: False
-  max_step_expl_decay: 0
   discrete_size: ${algo.world_model.discrete_size}

--- a/sheeprl/configs/algo/dreamer_v3.yaml
+++ b/sheeprl/configs/algo/dreamer_v3.yaml
@@ -106,6 +106,7 @@ actor:
   layer_norm: ${algo.layer_norm}
   dense_units: ${algo.dense_units}
   clip_gradients: 100.0
+  expl_amount: 0.0
   
   # Disttributed percentile model (used to scale the values)
   moments:
@@ -141,7 +142,6 @@ critic:
 # Player agent (it interacts with the environment)
 player:
   expl_min: 0.0
-  expl_amount: 0.0
   expl_decay: False
   max_step_expl_decay: 0
   discrete_size: ${algo.world_model.discrete_size}

--- a/sheeprl/configs/env/minedojo.yaml
+++ b/sheeprl/configs/env/minedojo.yaml
@@ -5,6 +5,7 @@ defaults:
 # Override from `minecraft` config
 id: open-ended
 action_repeat: 1
+capture_video: False
 
 # Wrapper to be instantiated
 wrapper:

--- a/sheeprl/configs/env/minedojo.yaml
+++ b/sheeprl/configs/env/minedojo.yaml
@@ -5,7 +5,7 @@ defaults:
 # Override from `minecraft` config
 id: open-ended
 action_repeat: 1
-capture_video: False
+capture_video: True
 
 # Wrapper to be instantiated
 wrapper:

--- a/sheeprl/envs/minedojo.py
+++ b/sheeprl/envs/minedojo.py
@@ -101,7 +101,7 @@ class MineDojoWrapper(gym.Wrapper):
                 "equipment": gym.spaces.Box(0.0, 1.0, (N_ALL_ITEMS,), np.int32),
                 "life_stats": gym.spaces.Box(0.0, np.array([20.0, 20.0, 300.0]), (3,), np.float32),
                 "mask_action_type": gym.spaces.Box(0, 1, (len(ACTION_MAP),), bool),
-                "mask_equip/place": gym.spaces.Box(0, 1, (N_ALL_ITEMS,), bool),
+                "mask_equip_place": gym.spaces.Box(0, 1, (N_ALL_ITEMS,), bool),
                 "mask_destroy": gym.spaces.Box(0, 1, (N_ALL_ITEMS,), bool),
                 "mask_craft_smelt": gym.spaces.Box(0, 1, (len(ALL_CRAFT_SMELT_ITEMS),), bool),
             }
@@ -131,7 +131,10 @@ class MineDojoWrapper(gym.Wrapper):
             else:
                 self._inventory[item].append(i)
             # count the items in the inventory
-            converted_inventory[ITEM_NAME_TO_ID[item]] += quantity
+            if item == "air":
+                converted_inventory[ITEM_NAME_TO_ID[item]] += 1
+            else:
+                converted_inventory[ITEM_NAME_TO_ID[item]] += quantity
         self._inventory_max = np.maximum(converted_inventory, self._inventory_max)
         return converted_inventory
 
@@ -168,7 +171,7 @@ class MineDojoWrapper(gym.Wrapper):
         masks["action_type"][7] *= np.any(destroy_mask).item()
         return {
             "mask_action_type": np.concatenate((np.array([True] * 12), masks["action_type"][1:])),
-            "mask_equip/place": equip_mask,
+            "mask_equip_place": equip_mask,
             "mask_destroy": destroy_mask,
             "mask_craft_smelt": masks["craft_smelt"],
         }

--- a/sheeprl/envs/minedojo.py
+++ b/sheeprl/envs/minedojo.py
@@ -11,7 +11,9 @@ from typing import Any, Dict, Optional, SupportsFloat, Tuple
 import gymnasium as gym
 import minedojo
 import numpy as np
+from gymnasium.core import RenderFrame
 from minedojo.sim import ALL_CRAFT_SMELT_ITEMS, ALL_ITEMS
+from minedojo.sim.wrappers.ar_nn import ARNNWrapper
 
 N_ALL_ITEMS = len(ALL_ITEMS)
 ACTION_MAP = {
@@ -77,7 +79,7 @@ class MineDojoWrapper(gym.Wrapper):
                 f"The initial position must respect the pitch limits {self._pitch_limits}, given {self._pos['pitch']}"
             )
 
-        env = minedojo.make(
+        env: ARNNWrapper = minedojo.make(
             task_id=id,
             image_size=(height, width),
             world_seed=seed,
@@ -287,3 +289,13 @@ class MineDojoWrapper(gym.Wrapper):
             "location_stats": copy.deepcopy(self._pos),
             "biomeid": float(obs["location_stats"]["biome_id"].item()),
         }
+
+    def render(self) -> RenderFrame | list[RenderFrame] | None:
+        if self.render_mode == "human":
+            super().render()
+        elif self.render_mode == "rgb_array":
+            if self.env.unwrapped._prev_obs is None:
+                return None
+            else:
+                return self.env.unwrapped._prev_obs["rgb"]
+        return None


### PR DESCRIPTION
## Summary

Describe the purpose of the pull request, including:

- Fix minedojo wrapper: removed `/` from the name of the observations to a correct creation of the memmap files when memmap buffer is used.
- Moved exploratory action from `Player` to `MinedojoActor` for dreamer-based algorithms. In this way, the player is general and can be used with all the environments. Instead, for using an environment that needs to mask actions, the user has to define a custom actor (as the `MinedojoActor`).
- In Dreamer-like algorithms, now, the `Actor` defines the `add_exploration_noise` method that takes in input the actions and adds to them some noise.
- In Dreamer-like algorithms, the exploration configs now must be defined under the `algo.actor` key, not under the `algo.player` one.

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

## Screenshots or Visuals (Optional)

If applicable, please provide screenshots, diagrams, graphs, or videos of the changes, features or the error.

## Additional Information (Optional)

Please provide any additional information that may be useful for the reviewer, such as:

- Any potential risks or challenges associated with the changes.
- Any instructions for testing or running the code.
- Any other relevant information.

Thank you for your contribution! Once you have filled out this template, please ensure that you have assigned the appropriate reviewers and that all tests have passed.
