### PR TITLE
Import user-defined evaluation file

### DIFF
--- a/sheeprl/cli.py
+++ b/sheeprl/cli.py
@@ -186,12 +186,14 @@ def eval_algorithm(cfg: DictConfig):
     # the entrypoint will be launched by Fabric with `fabric.launch(entrypoint)`
     module = None
     entrypoint = None
+    evaluation_file = None
     algo_name = cfg.algo.name
     for _module, _algos in evaluation_registry.items():
         for _algo in _algos:
             if algo_name == _algo["name"]:
                 module = _module
                 entrypoint = _algo["entrypoint"]
+                evaluation_file = _algo["evaluation_file"]
                 break
     if module is None:
         raise RuntimeError(f"Given the algorithm named `{algo_name}`, no module has been found to be imported.")
@@ -200,7 +202,12 @@ def eval_algorithm(cfg: DictConfig):
             f"Given the module and algorithm named `{module}` and `{algo_name}` respectively, "
             "no entrypoint has been found to be imported."
         )
-    task = importlib.import_module(f"{module}.evaluate")
+    if evaluation_file is None:
+        raise RuntimeError(
+            f"Given the module and algorithm named `{module}` and `{algo_name}` respectively, "
+            "no evaluation file has been found to be imported."
+        )
+    task = importlib.import_module(f"{module}.{evaluation_file}")
     command = task.__dict__[entrypoint]
     fabric.launch(command, cfg, state)
 


### PR DESCRIPTION
## Summary

In the `sheeprl.cli.eval_algorithm` method we still import the evaluation file with `task = importlib.import_module(f"{module}.evaluate")`, with the `sheeprl/{algo_name}/evaluate.py` file that could be missing since the user could have changed its name. The entrypoint filename can be retrieved from the `evaluation_registry`.

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

Thank you for your contribution! Once you have filled out this template, please ensure that you have assigned the appropriate reviewers and that all tests have passed.
