### PR TITLE
Downgrade PyTorch to 2.1 due to NetworkError on windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "torchmetrics",
   "rich==13.5.*",
   "opencv-python==4.8.0.*",
-  "torch>=2.0"
+  "torch>=2.0,<2.2"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

`torch==2.2` raises an `torch.distributed.DistNetworkError: Unknown error` error on Windows from the `torch\distributed\rendezvous.py:174: DistNetworkError` line. This PR reverts it back to `2.1`

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

Thank you for your contribution! Once you have filled out this template, please ensure that you have assigned the appropriate reviewers and that all tests have passed.
