### PR TITLE
Fix/evaluate no grad

### DIFF
--- a/sheeprl/cli.py
+++ b/sheeprl/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import hydra
+import torch
 from lightning import Fabric
 from lightning.fabric.strategies import STRATEGY_REGISTRY, DDPStrategy, SingleDeviceStrategy, Strategy
 from omegaconf import DictConfig, OmegaConf, open_dict
@@ -209,6 +210,8 @@ def eval_algorithm(cfg: DictConfig):
         )
     task = importlib.import_module(f"{module}.{evaluation_file}")
     command = task.__dict__[entrypoint]
+    if getattr(cfg, "disable_grads", True):
+        command = torch.no_grad(command)
     fabric.launch(command, cfg, state)
 
 

--- a/sheeprl/configs/eval_config.yaml
+++ b/sheeprl/configs/eval_config.yaml
@@ -17,4 +17,5 @@ fabric:
 env:
   capture_video: True
 
+disable_grads: True
 checkpoint_path: ???

--- a/sheeprl/utils/registry.py
+++ b/sheeprl/utils/registry.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import sys
 from typing import Any, Callable, Dict, List
 
-import torch
-
 # Mapping of tasks with their relative algorithms.
 # A new task can be added as:
 # tasks[module] = [..., {"name": algorithm, "entrypoint": entrypoint, "decoupled": decoupled}]
@@ -37,13 +35,7 @@ def _register_algorithm(fn: Callable[..., Any], decoupled: bool = False) -> Call
     return fn
 
 
-def _register_evaluation(
-    fn: Callable[..., Any], algorithms: str | List[str], disable_grads: bool = True
-) -> Callable[..., Any]:
-    # Disable gradient computation for evaluation
-    if disable_grads and torch.is_grad_enabled():
-        fn = torch.no_grad(fn)
-
+def _register_evaluation(fn: Callable[..., Any], algorithms: str | List[str]) -> Callable[..., Any]:
     # lookup containing module
     if fn.__module__ == "__main__":
         return fn
@@ -109,8 +101,8 @@ def register_algorithm(decoupled: bool = False):
     return inner_decorator
 
 
-def register_evaluation(algorithms: str | List[str], disable_grads: bool = True):
+def register_evaluation(algorithms: str | List[str]):
     def inner_decorator(fn):
-        return _register_evaluation(fn, algorithms=algorithms, disable_grads=disable_grads)
+        return _register_evaluation(fn, algorithms=algorithms)
 
     return inner_decorator


### PR DESCRIPTION
## Summary

This PR fixes a problem related to the increasing memory consuption for dreamer-v3 during the evaluation phase. In particular it let the user choose whether to disable gradients during the evaluation phase with the config parameter `disable_grads`, i.e. one can launch an evaluation with:

```bash
python sheeprl_eval.py checkpoint_path=/path/to/checkpoint.ckpt disable_grads=True
```

## Type of Change

Please select the one relevant option below:

- New feature (non-breaking change that adds functionality)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

Thank you for your contribution! Once you have filled out this template, please ensure that you have assigned the appropriate reviewers and that all tests have passed.
