### PR TITLE
Add dv3 different sizes configs

### DIFF
--- a/sheeprl/configs/algo/dreamer_v3.yaml
+++ b/sheeprl/configs/algo/dreamer_v3.yaml
@@ -1,3 +1,5 @@
+# Dreamer-V3 XL configuration
+
 defaults:
   - default
   - /optim@world_model.optimizer: adam

--- a/sheeprl/configs/algo/dreamer_v3_L.yaml
+++ b/sheeprl/configs/algo/dreamer_v3_L.yaml
@@ -1,0 +1,15 @@
+defaults:
+  - dreamer_v3_XL
+  - _self_
+
+dense_units: 768
+mlp_layers: 4
+world_model:
+  encoder:
+    cnn_channels_multiplier: 64
+  recurrent_model:
+    recurrent_state_size: 2048
+  transition_model:
+    hidden_size: 768
+  representation_model:
+    hidden_size: 768

--- a/sheeprl/configs/algo/dreamer_v3_M.yaml
+++ b/sheeprl/configs/algo/dreamer_v3_M.yaml
@@ -1,0 +1,15 @@
+defaults:
+  - dreamer_v3_XL
+  - _self_
+
+dense_units: 640
+mlp_layers: 3
+world_model:
+  encoder:
+    cnn_channels_multiplier: 48
+  recurrent_model:
+    recurrent_state_size: 1024
+  transition_model:
+    hidden_size: 640
+  representation_model:
+    hidden_size: 640

--- a/sheeprl/configs/algo/dreamer_v3_S.yaml
+++ b/sheeprl/configs/algo/dreamer_v3_S.yaml
@@ -1,0 +1,15 @@
+defaults:
+  - dreamer_v3_XL
+  - _self_
+
+dense_units: 512
+mlp_layers: 2
+world_model:
+  encoder:
+    cnn_channels_multiplier: 32
+  recurrent_model:
+    recurrent_state_size: 512
+  transition_model:
+    hidden_size: 512
+  representation_model:
+    hidden_size: 512

--- a/sheeprl/configs/algo/dreamer_v3_XL.yaml
+++ b/sheeprl/configs/algo/dreamer_v3_XL.yaml
@@ -1,0 +1,15 @@
+defaults:
+  - dreamer_v3
+  - _self_
+
+dense_units: 1024
+mlp_layers: 5
+world_model:
+  encoder:
+    cnn_channels_multiplier: 96
+  recurrent_model:
+    recurrent_state_size: 4096
+  transition_model:
+    hidden_size: 1024
+  representation_model:
+    hidden_size: 1024

--- a/sheeprl/configs/algo/dreamer_v3_XS.yaml
+++ b/sheeprl/configs/algo/dreamer_v3_XS.yaml
@@ -1,0 +1,15 @@
+defaults:
+  - dreamer_v3_XL
+  - _self_
+
+dense_units: 256
+mlp_layers: 1
+world_model:
+  encoder:
+    cnn_channels_multiplier: 24
+  recurrent_model:
+    recurrent_state_size: 256
+  transition_model:
+    hidden_size: 256
+  representation_model:
+    hidden_size: 256

--- a/sheeprl/configs/exp/dreamer_v3.yaml
+++ b/sheeprl/configs/exp/dreamer_v3.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 
 defaults:
-  - override /algo: dreamer_v3
+  - override /algo: dreamer_v3_S
   - override /env: atari
   - override /model_manager: dreamer_v3
   - _self_

--- a/sheeprl/configs/exp/dreamer_v3_100k_boxing.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_100k_boxing.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_S
   - override /env: atari
   - _self_
 
@@ -29,17 +30,6 @@ buffer:
 
 # Algorithm
 algo:
-  mlp_layers: 2
   train_every: 1
-  dense_units: 512
   total_steps: 100000
   learning_starts: 1024
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 32
-    recurrent_model:
-      recurrent_state_size: 512
-    transition_model:
-      hidden_size: 512
-    representation_model:
-      hidden_size: 512

--- a/sheeprl/configs/exp/dreamer_v3_100k_ms_pacman.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_100k_ms_pacman.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_S
   - override /env: atari
   - _self_
 
@@ -28,14 +29,3 @@ algo:
   learning_starts: 1024
   total_steps: 100000
   train_every: 1
-  dense_units: 512
-  mlp_layers: 2
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 32
-    recurrent_model:
-      recurrent_state_size: 512
-    transition_model:
-      hidden_size: 512
-    representation_model:
-      hidden_size: 512

--- a/sheeprl/configs/exp/dreamer_v3_L_doapp.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_L_doapp.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_L
   - override /env: diambra
   - _self_
 
@@ -30,17 +31,6 @@ buffer:
 algo:
   learning_starts: 65536
   train_every: 8
-  dense_units: 768
-  mlp_layers: 4
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 64
-    recurrent_model:
-      recurrent_state_size: 2048
-    transition_model:
-      hidden_size: 768
-    representation_model:
-      hidden_size: 768
   cnn_keys:
     encoder:
       - frame

--- a/sheeprl/configs/exp/dreamer_v3_L_doapp_128px_gray_combo_discrete.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_L_doapp_128px_gray_combo_discrete.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_L
   - override /env: diambra
   - _self_
 
@@ -38,17 +39,6 @@ algo:
   per_rank_batch_size: 8
   learning_starts: 65536
   train_every: 8
-  dense_units: 768
-  mlp_layers: 4
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 64
-    recurrent_model:
-      recurrent_state_size: 2048
-    transition_model:
-      hidden_size: 768
-    representation_model:
-      hidden_size: 768
   cnn_keys:
     encoder:
       - frame

--- a/sheeprl/configs/exp/dreamer_v3_L_navigate.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_L_navigate.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_L
   - override /env: minerl
   - _self_
 
@@ -29,17 +30,6 @@ buffer:
 algo:
   train_every: 16
   learning_starts: 65536
-  dense_units: 768
-  mlp_layers: 4
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 64
-    recurrent_model:
-      recurrent_state_size: 2048
-    transition_model:
-      hidden_size: 768
-    representation_model:
-      hidden_size: 768
   cnn_keys:
     encoder:
       - rgb

--- a/sheeprl/configs/exp/dreamer_v3_XL_crafter.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_XL_crafter.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_XL
   - override /env: crafter
   - _self_
 
@@ -26,17 +27,6 @@ buffer:
 algo:
   train_every: 2
   learning_starts: 1024
-  dense_units: 1024
-  mlp_layers: 5
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 96
-    recurrent_model:
-      recurrent_state_size: 4096
-    transition_model:
-      hidden_size: 1024
-    representation_model:
-      hidden_size: 1024
   cnn_keys:
     encoder:
       - rgb

--- a/sheeprl/configs/exp/dreamer_v3_dmc_walker_walk.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_dmc_walker_walk.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_S
   - override /env: dmc
   - _self_
 
@@ -37,17 +38,6 @@ algo:
     encoder: []
   learning_starts: 1024
   train_every: 2
-  dense_units: 512
-  mlp_layers: 2
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 32
-    recurrent_model:
-      recurrent_state_size: 512
-    transition_model:
-      hidden_size: 512
-    representation_model:
-      hidden_size: 512
 
 # Metric
 metric:

--- a/sheeprl/configs/exp/dreamer_v3_super_mario_bros.yaml
+++ b/sheeprl/configs/exp/dreamer_v3_super_mario_bros.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - dreamer_v3
+  - override /algo: dreamer_v3_S
   - override /env: super_mario_bros
   - _self_
 
@@ -28,17 +29,6 @@ algo:
     encoder: []
   learning_starts: 16384
   train_every: 4
-  dense_units: 512
-  mlp_layers: 2
-  world_model:
-    encoder:
-      cnn_channels_multiplier: 32
-    recurrent_model:
-      recurrent_state_size: 512
-    transition_model:
-      hidden_size: 512
-    representation_model:
-      hidden_size: 512
 
 # Metric
 metric:


### PR DESCRIPTION
## Summary

This PR let the user choose between different Dreamer-V3 agent sizes: XS, S, M, L and XL as defined in the paper. One can choose the preferred size through the CLI with

```bash
python sheeprl.py exp=dreamer_v3 env=gym env.id=CarRacing-v2 algo=dreamer_v3_M algo.cnn_keys.encoder=\[rgb\] fabric.accelerator=gpu fabric.devices=1 fabric.precision=bf16-mixed algo.learning_starts=1024
```

## Type of Change

Please select the one relevant option below:

- New feature (non-breaking change that adds functionality)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

Thank you for your contribution! Once you have filled out this template, please ensure that you have assigned the appropriate reviewers and that all tests have passed.
