### PR TITLE
Mock Fabric os.environ variables to be sure to have a SingleDeviceStrategy Fabric object

### DIFF
--- a/sheeprl/utils/fabric.py
+++ b/sheeprl/utils/fabric.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from lightning.fabric import Fabric
 from lightning.fabric.accelerators import XLAAccelerator
 from lightning.fabric.strategies import SingleDeviceStrategy, SingleDeviceXLAStrategy
@@ -23,4 +25,11 @@ def get_single_device_fabric(fabric: Fabric) -> Fabric:
         checkpoint_io=None,
         precision=fabric._precision,
     )
-    return Fabric(strategy=strategy)
+    with mock.patch.dict("os.environ") as mocked_os_environ:
+        mocked_os_environ.pop("LT_DEVICES", None)
+        mocked_os_environ.pop("LT_STRATEGY", None)
+        mocked_os_environ.pop("LT_NUM_NODES", None)
+        mocked_os_environ.pop("LT_PRECISION", None)
+        mocked_os_environ.pop("LT_ACCELERATOR", None)
+        fabric = Fabric(strategy=strategy)
+    return fabric

--- a/tests/test_utils/test_fabric.py
+++ b/tests/test_utils/test_fabric.py
@@ -1,0 +1,13 @@
+from lightning import Fabric
+from lightning.fabric.strategies import SingleDeviceStrategy
+
+from sheeprl.utils.fabric import get_single_device_fabric
+
+
+def test_get_single_device_fabric():
+    fabric = Fabric(devices=2, accelerator="cpu", precision=16)
+    single_device_fabric = get_single_device_fabric(fabric)
+    assert single_device_fabric.device == fabric.device
+    assert single_device_fabric._precision == fabric._precision
+    assert single_device_fabric.accelerator == fabric.accelerator
+    assert isinstance(single_device_fabric.strategy, SingleDeviceStrategy)


### PR DESCRIPTION
## Summary

This PR fixes a bug in get_single_device_fabric method where we now assure that the strategy is a SingleDeviceStrategy by forcing the env variables read by Fabric upon creation to be None

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

## Screenshots or Visuals (Optional)

If applicable, please provide screenshots, diagrams, graphs, or videos of the changes, features or the error.

## Additional Information (Optional)

Please provide any additional information that may be useful for the reviewer, such as:

- Any potential risks or challenges associated with the changes.
- Any instructions for testing or running the code.
- Any other relevant information.

Thank you for your contribution! Once you have filled out this template, please ensure that you have assigned the appropriate reviewers and that all tests have passed.
