### PR TITLE
Added toggle to train after game or after step in DreamerV3

### DIFF
--- a/sheeprl/algos/dreamer_v3/dreamer_v3.py
+++ b/sheeprl/algos/dreamer_v3/dreamer_v3.py
@@ -658,45 +658,46 @@ def main(fabric: Fabric, cfg: Dict[str, Any]):
 
         # Train the agent
         if iter_num >= learning_starts:
-            ratio_steps = policy_step - prefill_steps * policy_steps_per_iter
-            per_rank_gradient_steps = ratio(ratio_steps / world_size)
-            if per_rank_gradient_steps > 0:
-                local_data = rb.sample_tensors(
-                    cfg.algo.per_rank_batch_size,
-                    sequence_length=cfg.algo.per_rank_sequence_length,
-                    n_samples=per_rank_gradient_steps,
-                    dtype=None,
-                    device=fabric.device,
-                    from_numpy=cfg.buffer.from_numpy,
-                )
-                with timer("Time/train_time", SumMetric, sync_on_compute=cfg.metric.sync_on_compute):
-                    for i in range(per_rank_gradient_steps):
-                        if (
-                            cumulative_per_rank_gradient_steps % cfg.algo.critic.per_rank_target_network_update_freq
-                            == 0
-                        ):
-                            tau = 1 if cumulative_per_rank_gradient_steps == 0 else cfg.algo.critic.tau
-                            for cp, tcp in zip(critic.module.parameters(), target_critic.parameters()):
-                                tcp.data.copy_(tau * cp.data + (1 - tau) * tcp.data)
-                        batch = {k: v[i].float() for k, v in local_data.items()}
-                        train(
-                            fabric,
-                            world_model,
-                            actor,
-                            critic,
-                            target_critic,
-                            world_optimizer,
-                            actor_optimizer,
-                            critic_optimizer,
-                            batch,
-                            aggregator,
-                            cfg,
-                            is_continuous,
-                            actions_dim,
-                            moments,
-                        )
-                        cumulative_per_rank_gradient_steps += 1
-                    train_step += world_size
+            if cfg.algo.train_after_game or reset_envs > 0:
+                ratio_steps = policy_step - prefill_steps * policy_steps_per_iter
+                per_rank_gradient_steps = ratio(ratio_steps / world_size)
+                if per_rank_gradient_steps > 0:
+                    local_data = rb.sample_tensors(
+                        cfg.algo.per_rank_batch_size,
+                        sequence_length=cfg.algo.per_rank_sequence_length,
+                        n_samples=per_rank_gradient_steps,
+                        dtype=None,
+                        device=fabric.device,
+                        from_numpy=cfg.buffer.from_numpy,
+                    )
+                    with timer("Time/train_time", SumMetric, sync_on_compute=cfg.metric.sync_on_compute):
+                        for i in range(per_rank_gradient_steps):
+                            if (
+                                cumulative_per_rank_gradient_steps % cfg.algo.critic.per_rank_target_network_update_freq
+                                == 0
+                            ):
+                                tau = 1 if cumulative_per_rank_gradient_steps == 0 else cfg.algo.critic.tau
+                                for cp, tcp in zip(critic.module.parameters(), target_critic.parameters()):
+                                    tcp.data.copy_(tau * cp.data + (1 - tau) * tcp.data)
+                            batch = {k: v[i].float() for k, v in local_data.items()}
+                            train(
+                                fabric,
+                                world_model,
+                                actor,
+                                critic,
+                                target_critic,
+                                world_optimizer,
+                                actor_optimizer,
+                                critic_optimizer,
+                                batch,
+                                aggregator,
+                                cfg,
+                                is_continuous,
+                                actions_dim,
+                                moments,
+                            )
+                            cumulative_per_rank_gradient_steps += 1
+                        train_step += world_size
 
         # Log metrics
         if cfg.metric.log_level > 0 and (policy_step - last_log >= cfg.metric.log_every or iter_num == total_iters):

--- a/sheeprl/configs/exp/dreamer_v3.yaml
+++ b/sheeprl/configs/exp/dreamer_v3.yaml
@@ -8,6 +8,7 @@ defaults:
 
 # Algorithm
 algo:
+  train_after_step: true
   replay_ratio: 1
   total_steps: 5000000
   per_rank_batch_size: 16


### PR DESCRIPTION
## Summary

Describe the purpose of the pull request, including:

added a config called "train_after_step" to sheeprl\sheeprl\configs\exp\dreamer_v3.yaml. It is set to true by default which doesn't affect the standard way the program runs but if it's set to false it will make the program wait until the end of the episode/game to train the algorithm with all the data gathered.

## Type of Change

Please select the one relevant option below:

- New feature (non-breaking change that adds functionality)

## Checklist

Please confirm that the following tasks have been completed:

- [ yes] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [ no] I have added unit tests for my changes, or updated existing tests if necessary.
- [ no] I have updated the documentation, if applicable.
- [ n/a] I have installed pre-commit and run locally for my code changes.


